### PR TITLE
Add Portuguese translation for U-Touch

### DIFF
--- a/overlay/packages/apps/CMParts/res/values-pt/strings.xml
+++ b/overlay/packages/apps/CMParts/res/values-pt/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="hardware_keys_action">Ação</string>
+    <string name="hardware_keys_long_tap_key_title">Toque longo</string>
+    <string name="hardware_keys_swipe_left_key_title">Deslizar para a esquerda</string>
+    <string name="hardware_keys_swipe_right_key_title">Deslizar para a direita</string>
+    <string name="hardware_keys_utouch_settings_title">U-Touch</string>
+</resources>


### PR DESCRIPTION
U-Touch settings translated to Portuguese from Portugal (can be applied to Brazilian Portuguese, and other Portuguese alternatives).