### PR TITLE
Adding FlipFlap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.project

--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -144,7 +144,14 @@ VSYNC_EVENT_PHASE_OFFSET_NS := 2000000
 SF_VSYNC_EVENT_PHASE_OFFSET_NS := 6000000
 
 # Enable dexpreopt to speed boot time
-# WITH_DEXPREOPT := true
+ifeq ($(HOST_OS),linux)
+  ifneq ($(TARGET_BUILD_VARIANT),eng)
+    ifeq ($(WITH_DEXPREOPT),)
+      WITH_DEXPREOPT := true
+   endif
+  endif
+endif
+
 
 # Init
 TARGET_INIT_VENDOR_LIB := libinit_z2_plus

--- a/device.mk
+++ b/device.mk
@@ -274,6 +274,10 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     sensors.msm8996
 
+# FlipFlap
+PRODUCT_PACKAGES += \
+    FlipFlap
+
 # Wifi
 PRODUCT_PACKAGES += \
     ipacm \
@@ -307,3 +311,7 @@ PRODUCT_PACKAGES += \
 PRODUCT_SYSTEM_SERVER_JARS += com.cyanogenmod.keyhandler
 # never dexopt the keyhandler
 $(call add-product-dex-preopt-module-config,com.cyanogenmod.keyhandler,disable)
+
+PRODUCT_PACKAGES += \
+   SnapdragonCamera
+

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -339,7 +339,7 @@
     <!-- Indicate whether closing the lid causes the device to go to sleep and opening
          it causes the device to wake up.
          The default is false. -->
-    <bool name="config_lidControlsSleep">true</bool>
+    <bool name="config_lidControlsSleep">false</bool>
 
     <!-- Indicate whether to allow the device to suspend when the screen is off
          due to the proximity sensor.  This resource should only be set to true

--- a/overlay/packages/apps/CMParts/res/values-de/strings.xml
+++ b/overlay/packages/apps/CMParts/res/values-de/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="hardware_keys_action">Aktion</string>
+    <string name="hardware_keys_long_tap_key_title">Lange drücken</string>
+    <string name="hardware_keys_swipe_left_key_title">Nach links wischen</string>
+    <string name="hardware_keys_swipe_right_key_title">Nach rechts wischen</string>
+</resources>

--- a/overlay/packages/apps/CMParts/res/values-ja/strings.xml
+++ b/overlay/packages/apps/CMParts/res/values-ja/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="hardware_keys_action">アクション</string>
+    <string name="hardware_keys_long_tap_key_title">長押し</string>
+    <string name="hardware_keys_swipe_left_key_title">左スワイプ</string>
+    <string name="hardware_keys_swipe_right_key_title">右スワイプ</string>
+    <string name="hardware_keys_utouch_settings_title">U-Touch</string>
+</resources>

--- a/overlay/packages/apps/FlipFlap/res/values/config.xml
+++ b/overlay/packages/apps/FlipFlap/res/values/config.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (c) 2017 The LineageOS Project
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ Also add information on how to contact you by electronic and paper mail.
+
+-->
+<resources>
+
+    <!-- Define Device Lid Style
+
+     1 HTC Style Dotcase
+     2 Asus/LG Style Circle Window Cover
+     3 Rectangular window Cover
+     4 Iceview style case where the entire screen is visible
+
+     For example, a device with Asus Circle Cover would set 2 -->
+    <integer name="config_deviceCoverType">1</integer>
+
+    <!-- Define main circle parameters (config_deviceCoverType == 1) -->
+    <integer name="x_offset" translatable="false">50</integer>
+    <integer name="y_offset" translatable="false">30</integer>
+    <integer name="radius_offset" translatable="false">10</integer>
+
+</resources>

--- a/overlay/packages/apps/FlipFlap/res/values/config.xml
+++ b/overlay/packages/apps/FlipFlap/res/values/config.xml
@@ -27,11 +27,11 @@
      4 Iceview style case where the entire screen is visible
 
      For example, a device with Asus Circle Cover would set 2 -->
-    <integer name="config_deviceCoverType">1</integer>
+    <integer name="config_deviceCoverType">2</integer>
 
-    <!-- Define main circle parameters (config_deviceCoverType == 1) -->
-    <integer name="x_offset" translatable="false">50</integer>
-    <integer name="y_offset" translatable="false">30</integer>
-    <integer name="radius_offset" translatable="false">10</integer>
+    <!-- Define main circle parameters (config_deviceCoverType == 2) -->
+    <integer name="x_offset" translatable="false">-10</integer>
+    <integer name="y_offset" translatable="false">-75</integer>
+    <integer name="radius_offset" translatable="false">-120</integer>
 
 </resources>

--- a/rootdir/init.qcom.rc
+++ b/rootdir/init.qcom.rc
@@ -200,8 +200,10 @@ on boot
     chmod 2770 /dev/socket/qmux_gps
 
     mkdir /persist/drm 0770 system system
-
     mkdir /persist/bluetooth 0770 bluetooth bluetooth
+    mkdir /persist/misc 0770 system system
+    mkdir /persist/alarm 0770 system system
+    mkdir /persist/time 0770 system system
 
     # Create NETMGR daemon socket area
     mkdir /dev/socket/netmgr 0750 radio radio


### PR DESCRIPTION
I got FlipFlap working and it's quite cool - when you close the cover, it shows a circular clock that changes colour if you're charging etc.
I'm new to git and I think I'm making a bit of a hash of it! Maybe instead of pulling this pull request you could cherrypick the commits called "Add FlipFlap and SnapdragonCamera" and "Set the FlipFlap configuration to fit the Zuk flip cover".

You need to add 
`<project path="packages/apps/FlipFlap" name="LineageOS/android_packages_apps_FlipFlap" remote="github"/>`
to your local manifest.
If you want SnapdragonCamera, then also add
`  <remote name="codeaurora" fetch="https://source.codeaurora.org/quic/la/platform/packages/apps" revision="camera.lnx.1.0-rel.1.0" />
  <project path="packages/apps/SnapdragonCamera" name="SnapdragonCamera" remote="codeaurora" />`
to your local manifest.