### PR TITLE
sepolicy: adress thermal engine denial

### DIFF
--- a/sepolicy/thermal-engine.te
+++ b/sepolicy/thermal-engine.te
@@ -4,4 +4,4 @@ allow thermal-engine sysfs_kgsl:file r_file_perms;
 allow thermal-engine system_data_file:dir w_dir_perms;
 allow thermal-engine thermal_data_file:file create_file_perms;
 allow thermal-engine sysfs_usb_supply:dir search;
-allow thermal-engine sysfs_usb_supply:file { read open };
+allow thermal-engine sysfs_usb_supply:file r_file_perms;

--- a/sepolicy/thermal-engine.te
+++ b/sepolicy/thermal-engine.te
@@ -4,4 +4,4 @@ allow thermal-engine sysfs_kgsl:file r_file_perms;
 allow thermal-engine system_data_file:dir w_dir_perms;
 allow thermal-engine thermal_data_file:file create_file_perms;
 allow thermal-engine sysfs_usb_supply:dir search;
-allow thermal-engine sysfs_usb_supply:file read;
+allow thermal-engine sysfs_usb_supply:file { read open };


### PR DESCRIPTION
[    8.023939] type=1400 audit(24063124.567:6): avc: denied { open } for pid=708 comm="thermal-engine" path="/sys/devices/soc/6a00000.ssusb/power_supply/usb/type" dev="sysfs" ino=39804 scontext=u:r:thermal-engine:s0 tcontext=u:object_r:sysfs_usb_supply:s0 tclass=file permissive=0